### PR TITLE
prevent duplicate midi_device_names entries

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -109,6 +109,7 @@ local function midi_target(x)
 end
 
 mod.hook.register('script_pre_init', 'nbin pre init', function()
+    midi_device_names = {}
     for i = 1, #midi.vports do -- query all ports
         midi_device[i] = midi.connect(i) -- connect each device
         table.insert(midi_device_names, "port " .. i .. ": " .. util.trim_string_to_width(midi_device[i].name, 40)) -- register its name


### PR DESCRIPTION
- Fixes issue with duplicate midi_device_names entries being created on subsequent script launches.
- Issue results in errors changing `midi source` param. Steps to reproduce: launch `nb` script twice and observe duplicates in `tab.print(params:lookup_param("nb in midi source").options)`